### PR TITLE
Copy peer dependencies to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,21 +34,28 @@
     "@material-ui/icons": "^3.0.2",
     "@material-ui/lab": "^3.0.0-alpha.30",
     "lodash": "^4.17.11",
-    "react": "^16.8.3",
     "react-dom": "^16.8.3",
+    "react": "^16.8.3",
     "styled-components": "^4.1.3"
   },
   "devDependencies": {
+    "@material-ui/core": "^3.9.2",
+    "@material-ui/icons": "^3.0.2",
+    "@material-ui/lab": "^3.0.0-alpha.30",
     "@types/jest": "24.0.9",
     "@types/lodash": "^4.14.121",
     "@types/material-ui": "^0.21.6",
     "@types/node": "11.9.5",
-    "@types/react": "^16.8.5",
     "@types/react-dom": "16.8.2",
+    "@types/react": "^16.8.5",
     "@types/styled-components": "^4.1.10",
     "babel-cli": "^6.26.0",
+    "lodash": "^4.17.11",
+    "react-dom": "^16.8.3",
     "react-scripts": "2.1.5",
     "react-test-renderer": "^16.8.3",
+    "react": "^16.8.3",
+    "styled-components": "^4.1.3",
     "typescript": "3.3.3333"
   }
 }


### PR DESCRIPTION
This makes working locally easier.