### PR TITLE
add yarn install to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A library of AI2 themed React components.
     ```bash
     git clone git@github.com:allenai/varnish.git
     cd varnish
+    yarn install
     ```
 
 1. Running the demo


### PR DESCRIPTION
Installation instructions failed without first installing dependencies, updated readme to fix. Not super familiar with environment isolation for JS, so if this needs scoping to some local environment let me know.
