### PR TITLE
Add basic table

### DIFF
--- a/ui/src/demo/pages/Design/Design.tsx
+++ b/ui/src/demo/pages/Design/Design.tsx
@@ -12,7 +12,8 @@ import {
     Links,
     Palette,
     Spacing,
-    Typography
+    Typography,
+    Tables
 } from '..';
 import {  LeftMenuPage } from '../Shared';
 import { AppRoute } from '../../AppRoute';
@@ -70,6 +71,11 @@ export class Design extends React.PureComponent<RouteComponentProps> {
             path: `${this.parentPath}/headers`,
             label: 'Header & Footer',
             component: Headers
+        },
+        {
+            path: `${this.parentPath}/tables`,
+            label: 'Tables',
+            component: Tables
         }
     ];
 

--- a/ui/src/demo/pages/Design/Tables.tsx
+++ b/ui/src/demo/pages/Design/Tables.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { RouteComponentProps } from 'react-router';
+
+import { BodySmall, ExternalLink } from '../../../lib/components';
+import { PageTitle, SectionWithDivider, DefaultLiveProvider } from '../Shared';
+
+const examples = {
+basic: `
+render(
+  <div>
+    <Table 
+      dataSource={[
+        {
+          key: '1',
+          name: 'John Brown',
+          age: 32,
+          address: 'New York No. 1 Lake Park',
+        },
+        {
+          key: '2',
+          name: 'Jim Green',
+          age: 42,
+          address: 'London No. 1 Lake Park',
+        },
+        {
+          key: '3',
+          name: 'Joe Black',
+          age: 32,
+          address: 'Sidney No. 1 Lake Park',
+        },
+      ]}
+      columns={[
+        {
+          title: 'Name',
+          dataIndex: 'name',
+          key: 'name',
+        },
+        {
+          title: 'Age',
+          dataIndex: 'age',
+          key: 'age',
+        },
+        {
+          title: 'Address',
+          dataIndex: 'address',
+          key: 'address',
+        }
+      ]}
+    />
+  </div>
+)
+`.trim(),
+}
+
+export class Tables extends React.PureComponent<RouteComponentProps> {
+    render() {
+        return (
+            <React.Fragment>
+                <PageTitle>Tables</PageTitle>
+
+                <h3>Appearance and Behavior</h3>
+                <BodySmall>
+                    <br/>We are extending the Ant Design Table component.
+                    <br/>For more information see the: <ExternalLink target="_blank" href="https://ant.design/components/table/">Ant Design Component</ExternalLink>
+                </BodySmall>
+
+                <SectionWithDivider>
+                    <h3>Usage</h3>
+                    <h4>Basic Ant Table</h4>
+                    The Basic Table includes support for tabular data.
+                    <DefaultLiveProvider code={examples.basic} />
+                </SectionWithDivider>
+            </React.Fragment>
+        )
+    }
+}

--- a/ui/src/demo/pages/Design/Tables.tsx
+++ b/ui/src/demo/pages/Design/Tables.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import styled from 'styled-components';
 import { RouteComponentProps } from 'react-router';
 
 import { BodySmall, ExternalLink } from '../../../lib/components';

--- a/ui/src/demo/pages/Design/Tables.tsx
+++ b/ui/src/demo/pages/Design/Tables.tsx
@@ -10,6 +10,7 @@ basic: `
 render(
   <div>
     <Table 
+      pagination={false}
       dataSource={[
         {
           key: '1',

--- a/ui/src/demo/pages/Shared/DefaultLiveProvider.tsx
+++ b/ui/src/demo/pages/Shared/DefaultLiveProvider.tsx
@@ -38,6 +38,7 @@ import {
     SelectOption,
     Spacer,
     SvgIcon,
+    Table,
     TextArea,
     TopMenu
  } from '../../../lib/components';
@@ -89,7 +90,8 @@ const globalScope = {
     Quote,
     Author,
     Code,
-    InlineCode
+    InlineCode,
+    Table
 };
 
 const StyledProvider = styled(LiveProvider)`

--- a/ui/src/demo/pages/index.ts
+++ b/ui/src/demo/pages/index.ts
@@ -10,3 +10,4 @@ export * from './Design/Links';
 export * from './Design/Palette';
 export * from './Design/Spacing';
 export * from './Design/Typography';
+export * from './Design/Tables';

--- a/ui/src/lib/components/Table.tsx
+++ b/ui/src/lib/components/Table.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Table as AntTable } from 'antd';
 
 export const Table = styled(AntTable)`
-  background-color: ${props => props.theme.color.N1.hex};
-  border: 1px solid ${props => props.theme.color.N4.hex};
+  background-color: ${props => props.theme.palette.background.light};
+  border: 1px solid ${props => props.theme.palette.border.main};
   border-radius: 4px;
 `;

--- a/ui/src/lib/components/Table.tsx
+++ b/ui/src/lib/components/Table.tsx
@@ -1,0 +1,4 @@
+import styled from 'styled-components';
+import { Table as AntTable } from 'antd';
+
+export const Table = styled(AntTable)``;

--- a/ui/src/lib/components/Table.tsx
+++ b/ui/src/lib/components/Table.tsx
@@ -1,4 +1,8 @@
 import styled from 'styled-components';
 import { Table as AntTable } from 'antd';
 
-export const Table = styled(AntTable)``;
+export const Table = styled(AntTable)`
+  background-color: ${props => props.theme.color.N1.hex};
+  border: 1px solid ${props => props.theme.color.N4.hex};
+  border-radius: 4px;
+`;

--- a/ui/src/lib/components/index.ts
+++ b/ui/src/lib/components/index.ts
@@ -8,3 +8,4 @@ export * from './link';
 export * from './MaxWidthCenteredContent';
 export * from './typography';
 export * from './icon';
+export * from './Table';


### PR DESCRIPTION
This PR:

* Adds the simplest possible table from Ant Design to Varnish
* Provides a demo page that looks like the following:

![Screen Shot 2019-07-30 at 2 42 41 PM](https://user-images.githubusercontent.com/10873798/62167595-6e04d000-b2d8-11e9-8eb4-b6b90fc4ce2e.png)
