### PR TITLE
Switch to functional style of `attrs`

### DIFF
--- a/ui/src/lib/components/button.tsx
+++ b/ui/src/lib/components/button.tsx
@@ -35,16 +35,11 @@ const toHexIfDefined = (c: Optional<Color>) => {
 }
 
 // todo: consider converting to use https://www.npmjs.com/package/styled-components-modifiers
-export const Button = styled(AntButton).attrs<{type?: string}>({
+export const Button = styled(AntButton).attrs<{type?: string}>((props: ComponentProps) => ({
     // only supporting types that we have styled
     // if the user wants an unsupported type, they should use Ant.Button directly
-    type: (props: ComponentProps) => {
-        if(!props.variant || props.variant === 'primary' || props.variant === 'link'){
-            return props.variant;
-        }
-        return 'default';
-    }
-})<ComponentProps>`
+    type: (!props.variant || props.variant === 'primary' || props.variant === 'link') ? props.variant : 'default',
+}))<ComponentProps>`
     && {
         height: auto;
         font-weight: ${props => valueOrDefault(props, b => b.fontWeight) };


### PR DESCRIPTION
The button component causes this warning to appear on the browser console: 
![image](https://user-images.githubusercontent.com/13790867/63372677-72526500-c33b-11e9-9530-7b94cf405347.png)

This change modifies the `attrs` call to use the newer functional style and removes the warning.

This fixes issue https://github.com/allenai/varnish/issues/118