### PR TITLE
Fix #72; Resolve an error we saw on `npm run start`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4646,17 +4646,22 @@
       }
     },
     "antd-theme-generator": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/antd-theme-generator/-/antd-theme-generator-1.2.3.tgz",
-      "integrity": "sha512-ij/i92jaFSi08vwZkQrOck87FUn6OI89wh0hyfx5o8AFUpo3PKZ0oRFrNverV8X56iI3Mve4qPnIdPz9pj/jVg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/antd-theme-generator/-/antd-theme-generator-1.2.2.tgz",
+      "integrity": "sha512-C5vICdA/GJgoru2obKhD4NVjpdB//XQAlEDBgbgY04fXWvSwykPbpqECncD1yV5DsM1ZS0xfnDOQBvTAXydUfA==",
       "dev": true,
       "requires": {
+        "@ant-design/icons": "^4.0.6",
+        "antd": "^4.1.5",
+        "antd-theme-generator": "^1.2.1",
         "glob": "^7.1.3",
         "hash.js": "^1.1.5",
         "less": "^3.9.0",
+        "less-bundle-promise": "1.0.7",
         "less-plugin-npm-import": "^2.1.0",
         "postcss": "^6.0.21",
-        "strip-css-comments": "^4.1.0"
+        "postcss-colors-only": "0.0.3",
+        "react-color": "^2.18.0"
       },
       "dependencies": {
         "chalk": {
@@ -7592,6 +7597,104 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-color-extractor": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/css-color-extractor/-/css-color-extractor-0.0.5.tgz",
+      "integrity": "sha1-tzeiVTMguDexLhJK/64D3VPErPI=",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.2.1",
+        "color": "^0.10.1",
+        "postcss": "^5.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "color": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
+          "integrity": "sha1-wEGI34KiCd3rzOzazT7DIPGTc58=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^0.5.3",
+            "color-string": "^0.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+          "dev": true
+        },
+        "color-string": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+          "dev": true,
+          "requires": {
+            "color-name": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "css-color-keywords": {
@@ -18285,6 +18388,12 @@
         "tslib": "^1.10.0"
       }
     },
+    "less-bundle-promise": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/less-bundle-promise/-/less-bundle-promise-1.0.7.tgz",
+      "integrity": "sha512-B4mN+YtkOxAPUHyorhup+ETVNZ9E1PO65sPhgPvDDHDVtR1oYRd87EbYVYOsU0Oev0MW/6MSouS5QYlhe7XrzA==",
+      "dev": true
+    },
     "less-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-5.0.0.tgz",
@@ -21920,6 +22029,78 @@
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+        }
+      }
+    },
+    "postcss-colors-only": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-colors-only/-/postcss-colors-only-0.0.3.tgz",
+      "integrity": "sha1-JMcTwhv9FsCyo+iD3YoQM/Te/kk=",
+      "dev": true,
+      "requires": {
+        "css-color-extractor": "~0",
+        "postcss": "^5.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         }
       }
     },
@@ -28310,15 +28491,6 @@
             "is-utf8": "^0.2.0"
           }
         }
-      }
-    },
-    "strip-css-comments": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-4.1.0.tgz",
-      "integrity": "sha512-azjRwrqk7nK21LU7QuL7DpDyPjvRROQvqPrNyyz6emdzbOh6fsNTvkSvUiThBLzC6+MN90rFu296VbPb/KV+3A==",
-      "dev": true,
-      "requires": {
-        "is-regexp": "^2.1.0"
       }
     },
     "strip-eof": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@typescript-eslint/parser": "^2.19.0",
     "antd-img-crop": "^3.1.1",
     "antd-pro-merge-less": "^3.0.3",
-    "antd-theme-generator": "^1.1.6",
+    "antd-theme-generator": "1.2.2",
     "babel-eslint": "^10.0.1",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "bisheng": "^1.5.1",


### PR DESCRIPTION
This fixes a series of errors we were seeing after running
`npm run start`.

I traced this down to `antd-theme-generator`, and in auditing
the code discovered that upstream had updated that dependency
recently. See:
https://github.com/ant-design/ant-design/pull/24291/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L173

I tried updating and sure enough -- it fixes the problem.
I'm not sure if this actually changes anything about what's output,
but it's nice to at least not see the error.