### PR TITLE
Set the CNAME.

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -27,3 +27,4 @@ jobs:
         PUBLISH_DIR: ./_site
       with:
         emptyCommits: false
+        cname: varnish.allenai.org


### PR DESCRIPTION
I think *not* setting this is causing the CNAME in our repository
settings to get unset everytime the site deploys.

This should hopefully resolve that. Here's the docs:
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-cname