### PR TITLE
Fix #92; Copy over the Shellac files.

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -67,6 +67,14 @@ if __name__ == "__main__":
                 print(f"renamed {os.path.relpath(antd_name, os.getcwd())} -> " +
                       f"{os.path.relpath(varnish_name, os.getcwd())}")
 
+            # ...and copy the files in `dist_varnish` into `dist`, so they're included too.
+            for filename in os.listdir(os.path.join(root, "dist_varnish")):
+                orig = os.path.join(root, "dist_varnish", filename)
+                new = os.path.join(root, "dist", filename)
+                shutil.move(orig, new)
+                print(f"moved {os.path.relpath(orig, os.getcwd())} -> " +
+                      f"{os.path.relpath(new, os.getcwd())}")
+
             if args.pack:
                 subprocess.check_call([ "npm", "pack" ])
             else:

--- a/shellac/build.ts
+++ b/shellac/build.ts
@@ -9,6 +9,9 @@ import { generateCSS } from './generateCSS';
 import { generateLESS } from './generateLESS';
 
 const distPath = path.join(__dirname, '..', 'dist_varnish');
+if (!fs.existsSync(distPath)) {
+  fs.mkdirSync(distPath);
+}
 
 const lessPath = path.join(distPath, 'varnish.less');
 fs.writeFileSync(lessPath, generateLESS(), 'utf-8');


### PR DESCRIPTION
In implementing the first pass I forgot to do this step. Things "worked"
because the NPM CDN we use falls back to prior versions of the file if one
doesn't exist in the latest.