### PR TITLE
Properly convert the markdown to HTML.

### DIFF
--- a/shellac/build.ts
+++ b/shellac/build.ts
@@ -28,7 +28,7 @@ const markdownPath = path.join(__dirname, 'template.md');
 const markdownContents = fs.readFileSync(markdownPath, 'utf-8');
 
 // Ditch the markdown bits.
-let html = markdownContents.replace(/(^```\n|)(\n```$)/, '');
+let html = markdownContents.replace(/^```\n/, '').replace(/```\n$/, '');
 
 // Inject a link to the CSS. The lack of a version specifier here means it always serves the
 // latest.For more on the CDN we use, see https://www.jsdelivr.com/.


### PR DESCRIPTION
In 1d2448593b01e1b85bf426c577f92cf59b53f836 I fixed Shellac so
that the files are included in the artifact we distribute to NPM.
In so doing I discovered that the mechanism I was using to strip
the markdown wasn't working. I think I "tested" by retrieving it
from the CDN, which returned an old version (as the prior bug
explained) so it "worked". This was sloppy on my part.

This time I took a look at what's being published to verify the
changes. This should do the trick and makes the regexp a bit
simpler by doing it in two passes.

After this goes out the door I'll publish another version to
fully verify that shellac is working, end to end.