### PR TITLE
Fix #96; Remove local styles that made the top menu look odd.

### DIFF
--- a/site/theme/template/Layout/Header/Navigation.less
+++ b/site/theme/template/Layout/Header/Navigation.less
@@ -2,52 +2,6 @@
 @import '../../../../../components/style/themes/default.less';
 @import './index.less';
 
-#nav {
-  height: 100%;
-  font-size: 14px;
-  font-family: Avenir, @font-family, sans-serif;
-  border: 0;
-
-  &.ant-menu-horizontal {
-    border-bottom: none;
-
-    & > .ant-menu-item,
-    & > .ant-menu-submenu {
-      min-width: 72px;
-      height: @header-height;
-      line-height: @header-height - @menu-item-border - 2px;
-      border-top: @menu-item-border solid transparent;
-
-      &:hover {
-        border-top: @menu-item-border solid @primary-color;
-        border-bottom: @menu-item-border solid transparent;
-      }
-    }
-
-    & .ant-menu-submenu-title .anticon {
-      margin: 0;
-    }
-
-    & > .ant-menu-submenu-open {
-      border-top: @menu-item-border solid @primary-color;
-      border-bottom: @menu-item-border solid transparent;
-    }
-
-    & > .ant-menu-item-selected {
-      border-top: @menu-item-border solid @primary-color;
-      border-bottom: @menu-item-border solid transparent;
-      a {
-        color: @primary-color;
-      }
-    }
-  }
-
-  & > .ant-menu-item,
-  & > .ant-menu-submenu {
-    text-align: center;
-  }
-}
-
 .header-link {
   color: @site-text-color;
 }

--- a/site/theme/template/Layout/Header/Navigation.less
+++ b/site/theme/template/Layout/Header/Navigation.less
@@ -2,6 +2,10 @@
 @import '../../../../../components/style/themes/default.less';
 @import './index.less';
 
+/* @allenai/varnish:
+   The #nav styles here were removed, as they were overriding the default
+   styles applied to the <Menu />. */
+
 .header-link {
   color: @site-text-color;
 }


### PR DESCRIPTION
This removes some styles from the demo site that were overriding the
default menu treatment.